### PR TITLE
Fix apisoftlimit API response model field name

### DIFF
--- a/py_kabusapi/response_model.py
+++ b/py_kabusapi/response_model.py
@@ -511,7 +511,7 @@ class ApisoftlimitApiResponse(BaseModel):
 
     Option: float  # オプションのワンショット上限 (枚)
     MiniOption: float  # ミニオプションのワンショット上限 (枚)
-    kabu_s_version: str  # kabuステーションのバージョン
+    kabuSVersion: str  # kabuステーションのバージョン
 
 
 # /margin/marginpremium/{symbol}


### PR DESCRIPTION
## Summary
- Fix `kabu_s_version` field name to `kabuSVersion` in `ApisoftlimitApiResponse` model to match actual API response format

## Problem
The apisoftlimit API was failing with validation error:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ApisoftlimitApiResponse
kabu_s_version
  Field required [type=missing, input_value={'Stock': 1.0, 'Margin': ...buSVersion': '5.34.0.0'}, input_type=dict]
```

## Root Cause
The API returns `kabuSVersion` (camelCase) but the Pydantic model was expecting `kabu_s_version` (snake_case).

## Solution
Updated the field name from `kabu_s_version` to `kabuSVersion` to match the actual API response format.

## Test Plan
- [x] Verified API response format with debug script
- [x] Updated model field name
- [x] Confirmed apisoftlimit API call now works without validation errors

🤖 Generated with [Claude Code](https://claude.ai/code)