### PR TITLE
docs: README.mdのGitHubリポジトリURLを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Python wrapper for kabuステーション API
 ### GitHubから直接インストール
 
 ```bash
-pip install git+https://github.com/yourusername/py-kabusapi.git
+pip install git+https://github.com/sk-guritech/py-kabusapi.git
 ```
 
 ### ローカルでの開発用インストール
 
 ```bash
-git clone https://github.com/yourusername/py-kabusapi.git
+git clone https://github.com/sk-guritech/py-kabusapi.git
 cd py-kabusapi
 pip install -e .
 ```


### PR DESCRIPTION
## Summary
README.mdのインストール手順に記載されているGitHubリポジトリURLを正しいものに修正しました。

## Changes
- `yourusername/py-kabusapi` → `sk-guritech/py-kabusapi` に変更

## Test plan
- [x] README.mdの変更を確認
- [x] URLが正しいリポジトリを指していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)